### PR TITLE
감정 레벨별 태그 추가 & 태그 색상 변경

### DIFF
--- a/Rebound Journal.xcodeproj/xcuserdata/doyeonjeong.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/Rebound Journal.xcodeproj/xcuserdata/doyeonjeong.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>SchemeUserState</key>
+	<dict>
+		<key>Rebound Journal.xcscheme_^#shared#^_</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>0</integer>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/Rebound Journal/Assets.xcassets/Colors/selectedTagBackground.colorset/Contents.json
+++ b/Rebound Journal/Assets.xcassets/Colors/selectedTagBackground.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xC1",
+          "green" : "0xD8",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xC1",
+          "green" : "0xD8",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Rebound Journal/Assets.xcassets/Colors/unselectedTagBackground.colorset/Contents.json
+++ b/Rebound Journal/Assets.xcassets/Colors/unselectedTagBackground.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xEB",
+          "green" : "0xEB",
+          "red" : "0xEB"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xEB",
+          "green" : "0xEB",
+          "red" : "0xEB"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Rebound Journal/Constants.swift
+++ b/Rebound Journal/Constants.swift
@@ -7,6 +7,13 @@
 
 import Foundation
 
+enum EmotionLevel {
+    case level0 // emotionTextsLevel0
+    case level1 // emotionTextsLevel1
+    case level2 // emotionTextsLevel2
+    case level3 // emotionTextsLevel3
+}
+
 struct Constants {
     struct ContentText {
         let shootTypeTitle = "어떤 슛을 남겨볼까요?"
@@ -19,10 +26,32 @@ struct Constants {
         let reviewShootingField = "짧아도 좋아요. 경험에 대해 적어봐요."
         let whatNextPlan = "앞으로의 계획은 어떤 것인가요?"
         let whatNextPlanField = "작은 것부터 생각해보아도 좋아요."
+
+        /// 긍정적
+        let emotionTextsLevel0 = ["기분이 좋은", "신나는", "자랑스러운", "의욕적인", "뿌듯한",
+                                  "상쾌한", "설레는", "감사한", "행복한", "자신감이 생긴",
+                                  "편안한", "만족한", "열정적인", "기대되는", "용기있는"]
+
+        /// 보통
+        let emotionTextsLevel1 = ["평범한", "일상적인", "중립적인", "무난한", "일반적인",
+                                  "보통의", "냉정한", "무감각한", "무관심한", "무표정한"]
+
+        /// 부정적
+        let emotionTextsLevel2 = ["실망스러운", "지루한", "어수선한", "괴로운", "불만족스러운",
+                                  "피곤한", "짜증나는", "슬픈", "불안한"]
+
+        /// 매우 부정적
+        let emotionTextsLevel3 = ["절망적인", "끔찍한", "비참한", "혐오스러운", "무서운",
+                                  "파괴적인", "쓸쓸한", "분노스러운", "좌절스러운", "무력한"]
         
-        let emotionTexts = ["기분이 좋은", "신나는", "자랑스러운", "의욕적인", "뿌듯한",
-                            "상쾌한", "설레는", "감사한", "행복한", "자신감이 생긴",
-                            "편안한", "만족한", "열정적인", "기대되는", "용기있는"]
+        func getEmotions(for level: EmotionLevel) -> [String] {
+            switch level {
+            case .level0: return emotionTextsLevel0
+            case .level1: return emotionTextsLevel1
+            case .level2: return emotionTextsLevel2
+            case .level3: return emotionTextsLevel3
+            }
+        }
     }
     
     struct SystemText {

--- a/Rebound Journal/View/Component/EmotionText.swift
+++ b/Rebound Journal/View/Component/EmotionText.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct EmotionText: View {
     
     // UI State
-    @State var emotions = Constants.ContentText().emotionTexts
+    @Binding var emotions: [String]
     @Binding var selectedTags: [String]
     @State private var showSheet = false
     @State private var inputText = ""
@@ -229,5 +229,5 @@ struct CreateEmotionView: View {
 }
 
 #Preview {
-    EmotionText(selectedTags: .constant([]))
+    //EmotionText(selectedTags: .constant([]))
 }

--- a/Rebound Journal/View/Component/EmotionText.swift
+++ b/Rebound Journal/View/Component/EmotionText.swift
@@ -25,7 +25,7 @@ struct EmotionText: View {
                     // MARK: alignment를 수정하면 태그 정렬 위치가 바뀜
                     EmotionTagLayout(alignment: .leading , spacing: 10) {
                         ForEach(emotions.filter{ selectedTags.contains($0) }, id: \.self) { tag in
-                            EmotionTagView(tag, .accentColor)
+                            EmotionTagView(tag, .selectedTagBackground)
                             // MARK: 애니메이션이 좀 더 이뻐짐
                                 .matchedGeometryEffect(id: tag, in: animation)
                                 .onTapGesture {
@@ -37,7 +37,7 @@ struct EmotionText: View {
                         }
                         // MARK: 선택한 태그는 보이지 않게 필터링
                         ForEach(emotions.filter{ !selectedTags.contains($0) }, id: \.self) { tag in
-                            EmotionTagView(tag, .gray)
+                            EmotionTagView(tag, .unselectedTagBackground)
                             // MARK: 애니메이션이 좀 더 이뻐짐
                                 .matchedGeometryEffect(id: tag, in: animation)
                                 .onTapGesture {
@@ -77,17 +77,17 @@ struct EmotionText: View {
     
     @ViewBuilder
     func EmotionTagView(_ tag: String, _ color: Color) -> some View {
+        let isSelected = color == Color.selectedTagBackground ? true : false
         HStack(spacing: 8) {
             Text(tag)
-                .font(.system(size: 16))
-                .fontWeight(.semibold)
+                .font(.system(size: 16, weight: .light))
         }
         .frame(height: 35)
-        .foregroundStyle(.default)
+        .foregroundStyle(isSelected ? .accent : .default)
         .padding(.horizontal, 10)
         .background {
             Capsule()
-                .fill(color.gradient)
+                .fill(color)
         }
     }
 }
@@ -229,5 +229,5 @@ struct CreateEmotionView: View {
 }
 
 #Preview {
-    //EmotionText(selectedTags: .constant([]))
+    EmotionText(emotions: .constant(["감정태그", "기분이 좋은"]),selectedTags: .constant(["감정태그"]))
 }

--- a/Rebound Journal/View/Component/EmotionTracker.swift
+++ b/Rebound Journal/View/Component/EmotionTracker.swift
@@ -10,14 +10,30 @@ import SwiftUI
 struct EmotionTracker: View {
     // Shared Dependencies
     @ObservedObject var viewModel: JournalCreatorViewModel
+    
     // UI State
     @State var emotionShape: ImageResource = .positiveCircle
     @State var emotionValue: Double = 0.0
     @State var emotionText: [String] = []
+    @State var selectedEmotionTags: [String] = []
+    
+    var currentEmotionLevel: EmotionLevel {
+        switch emotionValue {
+        case 0..<0.5: return .level0
+        case 0.5..<1.5: return .level1
+        case 1.5..<2.5: return .level2
+        default: return .level3
+        }
+    }
+    
+    // 기타 상태
     var isFirstEnter: Bool {
-        !viewModel.isSliderEditing && viewModel.emotionValue == nil}
-    var isSliderEditing: Bool {viewModel.isSliderEditing}
-    // etc
+        !viewModel.isSliderEditing && viewModel.emotionValue == nil
+    }
+    var isSliderEditing: Bool {
+        viewModel.isSliderEditing
+    }
+    
     var text = Constants.SystemText()
     
     var body: some View {
@@ -32,34 +48,48 @@ struct EmotionTracker: View {
                             .bold()
                             .padding()
                     } else if !isSliderEditing {
-                        EmotionText(selectedTags: $emotionText)
-                            .onChange(of: emotionText) { _, newValue in
+                        EmotionText(emotions: $emotionText, selectedTags: $selectedEmotionTags)
+                            .onChange(of: selectedEmotionTags) { _, newValue in
                                 viewModel.emotionText = newValue
                             }
-                            
-                    }
-                    else {
+                    } else {
                         FeelingShape(value: $emotionValue,
                                      currentFeelingShape: $emotionShape)
                     }
+                    
                     Spacer()
+                    
                     VerticalSlider(sliderValue: $emotionValue, isEdited: $viewModel.isSliderEditing)
                         .onChange(of: emotionValue) { _, newValue in
                             print("Slider: \(newValue)")
+                            
+                            // 감정 모양 업데이트
                             switch newValue {
-                            case 0...0.5:
+                            case 0..<0.5:
                                 emotionShape = .positiveCircle
-                            case 0.5...1.5:
+                            case 0.5..<1.5:
                                 emotionShape = .softSpikes
-                            case 1.5...2.5:
+                            case 1.5..<2.5:
                                 emotionShape = .sharpSpike
-                            case 2.5...3:
+                            case 2.5...:
                                 emotionShape = .thornball
                             default:
-                                emotionShape = .softSpikes
+                                emotionShape = .positiveCircle
+                            }
+                            
+                            // 감정 텍스트 업데이트
+                            switch currentEmotionLevel {
+                            case .level0:
+                                emotionText = Constants.ContentText().emotionTextsLevel0
+                            case .level1:
+                                emotionText = Constants.ContentText().emotionTextsLevel1
+                            case .level2:
+                                emotionText = Constants.ContentText().emotionTextsLevel2
+                            case .level3:
+                                emotionText = Constants.ContentText().emotionTextsLevel3
                             }
                         }
-                        .onChange(of: viewModel.isSliderEditing) { _, newValue in
+                        .onChange(of: viewModel.isSliderEditing) { _, _ in
                             viewModel.emotionValue = emotionValue
                         }
                         .frame(width: 60)
@@ -68,6 +98,7 @@ struct EmotionTracker: View {
         }
     }
 }
+
 
 struct FeelingShape: View {
     @Binding var value: Double

--- a/Rebound Journal/View/Component/VerticalSlider.swift
+++ b/Rebound Journal/View/Component/VerticalSlider.swift
@@ -19,7 +19,7 @@ struct VerticalSlider: View {
             GeometryReader { geometry in
                 ZStack {
                     Color.clear
-                        .frame(width: 20)
+                        .frame(width: 35)
                         .frame(maxHeight: geometry.size.height)
                         .overlay(
                             Slider(value: $sliderValue, in: 0...3) { editing in
@@ -33,13 +33,12 @@ struct VerticalSlider: View {
                                     }
                                 }
                             }
-                        )
+                                .rotationEffect(.degrees(-90))
+                                .frame(width: 350, height: 30))
                 }
-                            .rotationEffect(.degrees(-90))
-                            .frame(width: 350, height: 30)
                     .onChange(of: sliderValue) {
                         _, newValue in
-                        debugPrint(newValue)
+                        print(newValue)
                     }
             }
             
@@ -52,4 +51,3 @@ struct VerticalSlider: View {
 #Preview {
     VerticalSlider(sliderValue: .constant(1), isEdited: .constant(false))
 }
-


### PR DESCRIPTION
## 감정 레벨 태그 추가
![Simulator Screen Recording - iPhone 16 - 2025-05-18 at 23 01 15](https://github.com/user-attachments/assets/543c4958-f415-4a0d-a2f2-e5d0b3541311)

### 주요 변경사항
- `EmotionLevel` 추가
- `EmotionText`뷰에서 `@Binding emotions`으로 변경
- `EmotionTracker`에서 슬라이더 값에 맞는 태그 문자열 전달

## 감정 태그 색상 변경
![Simulator Screen Recording - iPhone 16 - 2025-05-19 at 00 14 49](https://github.com/user-attachments/assets/4adf7b6c-552a-4555-9171-9975fdf0d704)

### 주요 변경사항
- `selectedTagBackground` 컬러 추가
- `unselectedTagBackground` 컬러 추가
- `selectedTagBackground`인 경우 텍스트 `accent` 컬러로 변경되는 로직 추가

## 그 외
- 버튼이나 텍스트들에도 디자인 파일과 맞지 않는 부분 추후 수정하겠습니다.