### PR TITLE
[Fix]: 날짜 필터링 오류

### DIFF
--- a/Rebound Journal/Screen/HomeView.swift
+++ b/Rebound Journal/Screen/HomeView.swift
@@ -67,11 +67,11 @@ struct HomeView: View {
             return filteredByDate
         }
         
-        let nonReboundedNonDeleted = journals.filter {
-            !($0.isRebounded ?? false) && !($0.hasDeleted ?? false) && ($0.isGoalIn != nil)
+        let nonReboundedNonDeleted = filteredByDate.filter {
+            !($0.isRebounded ?? false) && !($0.hasDeleted ?? false)
         }
         
-        return Array(Set(nonReboundedNonDeleted + filteredByDate))
+        return nonReboundedNonDeleted
     }
     
     /// Check-in banner view


### PR DESCRIPTION
### 개요
캘린더와 상관없이 필터링되지 않은 데이터가 보이는 현상을 해결
해결 후 : 선택한 날짜에 해당하는 데이터를 화면에 표시

## 기존 함수
아래의 코드를 보면 오늘이 선택되었다면 filteredByDate를 반환하고 
그것이 아니라면
리바운드 여부와 삭제 여부로 필터링된 데이터와 합쳐서 반환하는 로직이다.
```swift
private func checkReboundList() -> [JournalData] {
        let isTodaySelected = Date().longFormat == manager.selectedDate.longFormat
        
        let filteredByDate = journals.filter {
            $0.date?.longFormat == manager.selectedDate.longFormat && !($0.hasDeleted ?? false)
        }
        
        guard isTodaySelected else {
            return filteredByDate
        }
        
        let nonReboundedNonDeleted = journals.filter {
            !($0.isRebounded ?? false) && !($0.hasDeleted ?? false) && ($0.isGoalIn != nil)
        }
        
        return Array(Set(nonReboundedNonDeleted + filteredByDate))
    }
```

발생한 에러는 날짜 필터링 기능이 되지 않아서인데 반환하는 데이터가 날짜 필터링과 무관한 데이터인 것 같아서
해당 부분을 수정하였다.

## 수정 함수
```swift
private func checkReboundList() -> [JournalData] {
        let isTodaySelected = Date().longFormat == manager.selectedDate.longFormat
        
        let filteredByDate = journals.filter {
            $0.date?.longFormat == manager.selectedDate.longFormat && !($0.hasDeleted ?? false)
        }
        
        guard isTodaySelected else {
            return filteredByDate
        }
        // 필터링된 데이터를 기준으로 추가 필터링
        let nonReboundedNonDeleted = filteredByDate.filter {
            !($0.isRebounded ?? false) && !($0.hasDeleted ?? false)
        }
        
        return nonReboundedNonDeleted
    }
```
### 이로써 날짜를 기준으로 필터링된 데이터만 볼 수 있다.