### PR TITLE
[Fix]: VerticalSlider UI 겹침 현상

### DIFF
--- a/Rebound Journal/View/Component/VerticalSlider.swift
+++ b/Rebound Journal/View/Component/VerticalSlider.swift
@@ -15,12 +15,14 @@ struct VerticalSlider: View {
     var body: some View {
         VStack {
             Text("부정")
+                .padding(.bottom, 16)
             
             GeometryReader { geometry in
+                let height = geometry.size.height
                 ZStack {
                     Color.clear
                         .frame(width: 35)
-                        .frame(maxHeight: geometry.size.height)
+                        .frame(maxHeight: height)
                         .overlay(
                             Slider(value: $sliderValue, in: 0...3) { editing in
                                 isEdited = editing
@@ -34,7 +36,7 @@ struct VerticalSlider: View {
                                 }
                             }
                                 .rotationEffect(.degrees(-90))
-                                .frame(width: 350, height: 30))
+                                .frame(width: height, height: 30))
                 }
                 .onChange(of: sliderValue) {
                     _, newValue in
@@ -43,6 +45,7 @@ struct VerticalSlider: View {
             }
             
             Text("긍정")
+                .padding(.top, 16)
         }
         .padding(10)
     }

--- a/Rebound Journal/View/Component/VerticalSlider.swift
+++ b/Rebound Journal/View/Component/VerticalSlider.swift
@@ -36,10 +36,10 @@ struct VerticalSlider: View {
                                 .rotationEffect(.degrees(-90))
                                 .frame(width: 350, height: 30))
                 }
-                    .onChange(of: sliderValue) {
-                        _, newValue in
-                        print(newValue)
-                    }
+                .onChange(of: sliderValue) {
+                    _, newValue in
+                    print(newValue)
+                }
             }
             
             Text("긍정")

--- a/Rebound Journal/View/JournalCreator/EmotionInputView.swift
+++ b/Rebound Journal/View/JournalCreator/EmotionInputView.swift
@@ -41,23 +41,6 @@ struct EmotionInputView: View {
             .padding()
         }
     }
-    
-    /// 세로형 슬라이더
-    private var verticalSlider: some View {
-        VStack {
-            Text("부정")
-            ZStack {
-                Color.clear
-                    .frame(width: 30, height: 400)
-                    .overlay(
-                        Slider(value: $sliderValue, in: 0...3, step: 1)
-                            .rotationEffect(.degrees(-90))
-                            .frame(width: 400, height: 30))
-            }
-            .animation(.easeIn(duration: 0.3), value: sliderValue)
-            Text("긍정")
-        }
-    }
 }
 
 #Preview("EmotionInputView: GoalIn") {


### PR DESCRIPTION
# 개요
수직 슬라이더가 기기에 따라 다르게 보이는 현상 해결
(긍정/부정 텍스트와 슬라이더가 겹쳐짐)

## 작업내용
- `Slider`의 크기를 `GeometryReader`를 통해 유동적으로 조절
```swift
GeometryReader { geometry in
    let height = geometry.size.height

    // 기존 코드
    .frame(width: 350, height: 30))
    // 수정 코드
    .frame(width: height, height: 30))
}
```