### PR TITLE
[Fix]: ReviewPlanView 관련 이상현상

### DIFF
--- a/Rebound Journal/View/JournalCreator/ReviewPlanView.swift
+++ b/Rebound Journal/View/JournalCreator/ReviewPlanView.swift
@@ -23,10 +23,7 @@ struct ReviewPlanView: View {
     @State var reviewText: String = ""
     @State var planText: String = ""
     @Binding var currentStep: ReboundProcessStep
-    var canSave: Bool {
-        guard let reviewText = viewModel.reviewText else { return false }
-        guard let planText = viewModel.nextPlanText else { return false }
-        return !reviewText.isEmpty && !planText.isEmpty}
+    var canSave: Bool { return !reviewText.isEmpty && !planText.isEmpty }
     var isReviewed: Bool {!reviewText.isEmpty || currentField == .review}
     var isPlaned: Bool {!planText.isEmpty || currentField == .plan}
     
@@ -124,6 +121,10 @@ struct ReviewPlanView: View {
                     }
                 }
             }
+        }
+        .onAppear() {
+            reviewText = viewModel.reviewText ?? ""
+            planText = viewModel.nextPlanText ?? ""
         }
         .padding()
     }

--- a/Rebound Journal/View/JournalCreator/ReviewPlanView.swift
+++ b/Rebound Journal/View/JournalCreator/ReviewPlanView.swift
@@ -97,11 +97,7 @@ struct ReviewPlanView: View {
             // StepControll
             StepControlView(
                 onPrevious: {
-                    if viewModel.subGoal == nil {
-                        currentStep = .createSubGoal
-                    } else {
-                        currentStep = .emotion
-                    }
+                    currentStep = .emotion
                 },
                 onNext: {
                     if viewModel.subGoal != nil {
@@ -110,7 +106,7 @@ struct ReviewPlanView: View {
                         manager.fullScreenMode = nil
                     }
                     else { currentStep = .createSubGoal }
-
+                    
                 },
                 canGoNext: canSave,
                 nextButtonText: (viewModel.subGoal != nil) ? systemText.saveButton : systemText.nextButton)


### PR DESCRIPTION
# 개요
토브가 작업 중 발견한 이상현상(=에러)를 해결하는 작업.
현상 1 : 이전 화면으로 되돌아갔는데 데이터는 사라지고 다음으로 버튼은 활성화
현상 2 : 이전 버튼을 누르면 계속 동일한 화면으로 이동하는 무한 루프

## 작업 내용
### 현상 1
화면이 나타날때마다(onAppear) 뷰모델의 데이터와 동기화 시켜서 해결하였음
### 현상 2
이전 버튼의 동작 로직을 수정하였음(조건문 삭제)
[자세한 내용은 여기로](https://github.com/hamsik22/Rebound-Journal/issues/18)