### PR TITLE
🐛 :: 기록 버튼 컬러 상이

### DIFF
--- a/Rebound Journal/Assets.xcassets/Colors/Button/BackButtonBorder.colorset/Contents.json
+++ b/Rebound Journal/Assets.xcassets/Colors/Button/BackButtonBorder.colorset/Contents.json
@@ -11,24 +11,6 @@
         }
       },
       "idiom" : "universal"
-    },
-    {
-      "appearances" : [
-        {
-          "appearance" : "luminosity",
-          "value" : "dark"
-        }
-      ],
-      "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "alpha" : "1.000",
-          "blue" : "0xC8",
-          "green" : "0xC8",
-          "red" : "0xC8"
-        }
-      },
-      "idiom" : "universal"
     }
   ],
   "info" : {

--- a/Rebound Journal/Assets.xcassets/Colors/TextColor.colorset/Contents.json
+++ b/Rebound Journal/Assets.xcassets/Colors/TextColor.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "display-p3",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.004",
-          "green" : "0.000",
-          "red" : "0.000"
+          "blue" : "0x01",
+          "green" : "0x00",
+          "red" : "0x00"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "1.000",
-          "green" : "1.000",
-          "red" : "1.000"
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFF"
         }
       },
       "idiom" : "universal"

--- a/Rebound Journal/Assets.xcassets/Colors/TextColor.colorset/Contents.json
+++ b/Rebound Journal/Assets.xcassets/Colors/TextColor.colorset/Contents.json
@@ -2,24 +2,6 @@
   "colors" : [
     {
       "color" : {
-        "color-space" : "display-p3",
-        "components" : {
-          "alpha" : "1.000",
-          "blue" : "0x01",
-          "green" : "0x00",
-          "red" : "0x00"
-        }
-      },
-      "idiom" : "universal"
-    },
-    {
-      "appearances" : [
-        {
-          "appearance" : "luminosity",
-          "value" : "dark"
-        }
-      ],
-      "color" : {
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",

--- a/Rebound Journal/Screen/Components/StepControlView.swift
+++ b/Rebound Journal/Screen/Components/StepControlView.swift
@@ -24,9 +24,9 @@ struct StepControlView: View {
     let onNext: () -> Void
     let nextButtonText: String
     let previousButtonText: String
-
+    
     private let constants = Constants.SystemText()
-
+    
     // MARK: - Initializer
     init(
         hasBackButton: Bool = false,
@@ -43,7 +43,7 @@ struct StepControlView: View {
         self.nextButtonText = nextButtonText ?? constants.nextButton
         self.previousButtonText = previousButtonText ?? constants.previousButton
     }
-
+    
     // MARK: - Body
     var body: some View {
         GeometryReader { geometry in
@@ -52,40 +52,40 @@ struct StepControlView: View {
                     previousButton
                         .frame(width: (geometry.size.width - 16) / 3)
                 }
-
+                
                 nextButton
                     .frame(width: hasBackButton ? (geometry.size.width - 16) * 2 / 3 : geometry.size.width)
             }
         }
         .frame(height: 50) // 버튼 높이 고정
     }
-
+    
     var previousButton: some View {
         Button {
             onPrevious?()
         } label: {
-						Text(previousButtonText)
-								.font(.system(size: 18, weight: .bold))
+            Text(previousButtonText)
+                .font(.system(size: 18, weight: .bold))
                 .padding()
-								.frame(maxWidth: .infinity)
-								.foregroundColor(.backButtonText)
+                .frame(maxWidth: .infinity)
+                .foregroundColor(.backButtonText)
                 .background(Color.clear)
                 .overlay(
                     RoundedRectangle(cornerRadius: 90)
-												.stroke(.backButtonBorder, lineWidth: 2)
+                        .stroke(.backButtonBorder, lineWidth: 2)
                 )
         }
     }
-
+    
     var nextButton: some View {
         Button {
             if canGoNext {
                 onNext()
             }
         } label: {
-						Text(nextButtonText)
+            Text(nextButtonText)
                 .font(.system(size: 18, weight: .bold))
-								.frame(maxWidth: .infinity)
+                .frame(maxWidth: .infinity)
                 .padding()
                 .background(canGoNext ? Color.accentColor : .disabledButtonBackground)
                 .foregroundColor(canGoNext ? .text : .disabledButtonText)
@@ -98,47 +98,47 @@ struct StepControlView: View {
 
 // MARK: - Preview
 #Preview("Both Buttons - Enabled") {
-   VStack(spacing: 20) {
-       StepControlView(
-           hasBackButton: true,
-           canGoNext: true,
-           onPrevious: { print("Previous tapped") },
-           onNext: { print("Next tapped") }
-       )
-       .padding()
-   }
+    VStack(spacing: 20) {
+        StepControlView(
+            hasBackButton: true,
+            canGoNext: true,
+            onPrevious: { print("Previous tapped") },
+            onNext: { print("Next tapped") }
+        )
+        .padding()
+    }
 }
 
 #Preview("Both Buttons - Disabled Next") {
-   VStack(spacing: 20) {
-       StepControlView(
-           hasBackButton: true,
-           canGoNext: false,
-           onPrevious: { print("Previous tapped") },
-           onNext: { print("Next tapped") }
-       )
-       .padding()
-   }
+    VStack(spacing: 20) {
+        StepControlView(
+            hasBackButton: true,
+            canGoNext: false,
+            onPrevious: { print("Previous tapped") },
+            onNext: { print("Next tapped") }
+        )
+        .padding()
+    }
 }
 
 #Preview("Next Button Only - Enabled") {
-   VStack(spacing: 20) {
-       StepControlView(
-           hasBackButton: false,
-           canGoNext: true,
-           onNext: { print("Next tapped") }
-       )
-       .padding()
-   }
+    VStack(spacing: 20) {
+        StepControlView(
+            hasBackButton: false,
+            canGoNext: true,
+            onNext: { print("Next tapped") }
+        )
+        .padding()
+    }
 }
 
 #Preview("Next Button Only - Disabled") {
-   VStack(spacing: 20) {
-       StepControlView(
-           hasBackButton: false,
-           canGoNext: false,
-           onNext: { print("Next tapped") }
-       )
-       .padding()
-   }
+    VStack(spacing: 20) {
+        StepControlView(
+            hasBackButton: false,
+            canGoNext: false,
+            onNext: { print("Next tapped") }
+        )
+        .padding()
+    }
 }

--- a/Rebound Journal/Screen/Components/StepControlView.swift
+++ b/Rebound Journal/Screen/Components/StepControlView.swift
@@ -142,3 +142,16 @@ struct StepControlView: View {
         .padding()
     }
 }
+
+#Preview("저장하기") {
+    VStack(spacing: 20) {
+        StepControlView(
+            hasBackButton: true,
+            canGoNext: true,
+            onPrevious: { print("Previous tapped") },
+            onNext: { print("Next tapped") },
+            nextButtonText: "저장하기"
+        )
+        .padding()
+    }
+}

--- a/Rebound Journal/Screen/Components/StepControlView.swift
+++ b/Rebound Journal/Screen/Components/StepControlView.swift
@@ -88,7 +88,7 @@ struct StepControlView: View {
 								.frame(maxWidth: .infinity)
                 .padding()
                 .background(canGoNext ? Color.accentColor : .disabledButtonBackground)
-                .foregroundColor(canGoNext ? .white : .disabledButtonText)
+                .foregroundColor(canGoNext ? .text : .disabledButtonText)
                 .cornerRadius(90)
         }
         .disabled(!canGoNext)

--- a/Rebound Journal/Screen/Home/DashboardContentView.swift
+++ b/Rebound Journal/Screen/Home/DashboardContentView.swift
@@ -195,7 +195,7 @@ struct DashboardContentView: View {
                     .frame(height: 60)
                     .bold()
                     .background(.tint)
-                    .foregroundStyle(.white)
+                    .foregroundStyle(.text)
                     .clipShape(RoundedRectangle(cornerRadius: 90))
             }
         }

--- a/Rebound Journal/Screen/Home/HomeView.swift
+++ b/Rebound Journal/Screen/Home/HomeView.swift
@@ -141,7 +141,7 @@ struct HomeView: View {
                 .frame(height: 60)
                 .bold()
                 .background(.tint)
-                .foregroundStyle(.white)
+                .foregroundStyle(.text)
                 .clipShape(RoundedRectangle(cornerRadius: 90))
                 .padding(.horizontal)
             // SE 대응 패딩


### PR DESCRIPTION
# 작업내용
버튼의 텍스트컬러를 `.white -> .text` 로 변경

## 버그 원인
텍스트컬러를 `.white`로 설정하여 다크/라이트 모드에 따라 색상이 변경되었음.
하지만 디자인 기획상 버튼 텍스트 컬러는 `#FFFFFF`로 고정이기에
`Asset`의 `TextColor`를 사용하여 적용하였음.
`Appearances = None`으로 변경 후 피그마와 동일한 `#FFFFFF`로 수정하여 해결

### 관련 이슈
close #46 