### PR TITLE
✨ :: FullScreenCover -> NavigationStack

### DIFF
--- a/Rebound Journal/Screen/Home/DashboardContentView.swift
+++ b/Rebound Journal/Screen/Home/DashboardContentView.swift
@@ -38,7 +38,7 @@ struct DashboardContentView: View {
         .fullScreenCover(item: $manager.fullScreenMode) { type in
             switch type {
             case .entryCreator:
-                JounrnalCreator(viewModel: journalCreatorViewModel, currentStep: $journalCreatorStep)
+                JounrnalCreator(viewModel: journalCreatorViewModel)
                     .environmentObject(manager)
             case .readJournalView:
                 // TODO: 기록 상세화면

--- a/Rebound Journal/Screen/Home/DashboardContentView.swift
+++ b/Rebound Journal/Screen/Home/DashboardContentView.swift
@@ -20,7 +20,6 @@ struct DashboardContentView: View {
     @Query private var subGoals: [SubGoalData]
     @State private var isSettingsSheetPresented = false
     @State private var isHistorySheetPresented = false
-    @State private var journalCreatorStep: ReboundProcessStep = .createSubGoal
     
     let columns = [GridItem(.flexible()), GridItem(.flexible())]
     
@@ -66,7 +65,6 @@ struct DashboardContentView: View {
             // 중복되지 않는 CoreData를 SwiftData로 옮기는 함수
             manager.convertDupicateDataToSwiftData(nsContext: context, modelContext: modelContext)
             // 작은 목표 유무에 따라 슛 생성 화면 상태값 수정
-            journalCreatorStep = subGoals.isEmpty ? .shoot : .selectSubGoal
             
         }
         .sheet(isPresented: $isSettingsSheetPresented) {

--- a/Rebound Journal/Screen/Journal/Creation/JounrnalCreator.swift
+++ b/Rebound Journal/Screen/Journal/Creation/JounrnalCreator.swift
@@ -14,7 +14,6 @@ struct JounrnalCreator: View {
     @EnvironmentObject var manager: DataManager
     @ObservedObject var viewModel: JournalCreatorViewModel
     // UI State
-    @Binding var currentStep: ReboundProcessStep
     @State private var showAlert: Bool = false
     @Query private var subGoals: [SubGoalData]
     @State private var path = NavigationPath()
@@ -25,7 +24,7 @@ struct JounrnalCreator: View {
                 manager.fullScreenMode = nil
             }, hasAlert: true)
             NavigationStack(path: $path) {
-                SelectTargetView(viewModel: viewModel, subGoals: subGoals, path: $path)
+                    startingView()
                     .navigationDestination(for: JournalCreationState.self) { value in
                         switch value {
                         case .createSubGoal:
@@ -48,6 +47,15 @@ struct JounrnalCreator: View {
             }
         }
     }
+    
+    @ViewBuilder
+    private func startingView() -> some View {
+        if subGoals.isEmpty {
+            SelectShootTypeView(viewModel: viewModel, path: $path)
+        } else {
+            SelectTargetView(viewModel: viewModel, subGoals: subGoals, path: $path)
+        }
+    }
 }
 
 enum JournalCreationState: Hashable {
@@ -59,6 +67,6 @@ enum JournalCreationState: Hashable {
 }
 
 #Preview {
-    JounrnalCreator(viewModel: JournalCreatorViewModel(), currentStep: .constant(.createSubGoal))
+    JounrnalCreator(viewModel: JournalCreatorViewModel())
         .environmentObject(DataManager())
 }

--- a/Rebound Journal/Screen/Journal/Creation/JounrnalCreator.swift
+++ b/Rebound Journal/Screen/Journal/Creation/JounrnalCreator.swift
@@ -41,7 +41,7 @@ struct JounrnalCreator: View {
                             EmotionInputView(viewModel: viewModel, path: $path)
                                 .navigationBarBackButtonHidden()
                         case .review:
-                            ReviewPlanView(viewModel: viewModel, currentStep: $currentStep, path: $path)
+                            ReviewPlanView(viewModel: viewModel, path: $path)
                                 .navigationBarBackButtonHidden()
                         }
                     }

--- a/Rebound Journal/Screen/Journal/Creation/JounrnalCreator.swift
+++ b/Rebound Journal/Screen/Journal/Creation/JounrnalCreator.swift
@@ -17,23 +17,45 @@ struct JounrnalCreator: View {
     @Binding var currentStep: ReboundProcessStep
     @State private var showAlert: Bool = false
     @Query private var subGoals: [SubGoalData]
+    @State private var path = NavigationPath()
     
     var body: some View {
         VStack {
             ModalHeaderBar(onDismiss:  {
                 manager.fullScreenMode = nil
             }, hasAlert: true)
-            switch currentStep {
-            case .selectSubGoal: SelectTargetView(viewModel: viewModel, currentStep: $currentStep, subGoals: subGoals)
-            case .shoot: SelectShootTypeView(viewModel: viewModel, currentStep: $currentStep)
-            case .emotion: EmotionInputView(viewModel: viewModel, currentStep: $currentStep)
-            case .review: ReviewPlanView(viewModel: viewModel, currentStep: $currentStep)
-                    .environmentObject(manager)
-            case .createSubGoal: CreateTargetView(viewModel: viewModel, currentStep: $currentStep)
-                    .environmentObject(manager)
+            NavigationStack(path: $path) {
+                SelectTargetView(viewModel: viewModel, subGoals: subGoals, path: $path)
+                    .navigationDestination(for: JournalCreationState.self) { value in
+                        switch value {
+                        case .createSubGoal:
+                            CreateTargetView(viewModel: viewModel, path: $path)
+                                .navigationBarBackButtonHidden()
+                        case .selectSubGoal:
+                            SelectTargetView(viewModel: viewModel, subGoals: subGoals, path: $path)
+                                .navigationBarBackButtonHidden()
+                        case .shoot:
+                            SelectShootTypeView(viewModel: viewModel, path: $path)
+                                .navigationBarBackButtonHidden()
+                        case .emotion:
+                            EmotionInputView(viewModel: viewModel, path: $path)
+                                .navigationBarBackButtonHidden()
+                        case .review:
+                            ReviewPlanView(viewModel: viewModel, currentStep: $currentStep, path: $path)
+                                .navigationBarBackButtonHidden()
+                        }
+                    }
             }
         }
     }
+}
+
+enum JournalCreationState: Hashable {
+    case selectSubGoal,
+         shoot,
+         emotion,
+         review,
+         createSubGoal
 }
 
 #Preview {

--- a/Rebound Journal/Screen/Journal/Creation/SubView/EmotionInputView.swift
+++ b/Rebound Journal/Screen/Journal/Creation/SubView/EmotionInputView.swift
@@ -15,8 +15,9 @@ struct EmotionInputView: View {
     // UI State
     @State private var sliderValue: Double = 0.5
     var canGoNext: Bool {
-        viewModel.emotionValue != nil && (viewModel.emotionText != [] && viewModel.emotionText != nil)}
-    @Binding var currentStep: ReboundProcessStep
+        viewModel.emotionValue != nil && (viewModel.emotionText != [] && viewModel.emotionText != nil)
+    }
+    @Binding var path: NavigationPath
     // etc
     var text = Constants.ContentText()
     
@@ -36,15 +37,21 @@ struct EmotionInputView: View {
                 hasBackButton: true,
                 canGoNext: canGoNext,
                 onPrevious: {
-                    currentStep = .shoot
+                  onPreviousTapped()
                 },
                 onNext: {
-                    currentStep = .review
+                    onNextTapped()
                 },
                 nextButtonText: "다음으로"
             )
             .padding()
         }
+    }
+    private func onPreviousTapped() {
+        path.removeLast()
+    }
+    private func onNextTapped() {
+        path.append(JournalCreationState.review)
     }
 }
 
@@ -54,7 +61,7 @@ struct EmotionInputView: View {
         vm.goalType = true
         return vm
     }()
-    EmotionInputView(viewModel: viewModel, currentStep: .constant(.createSubGoal))
+    EmotionInputView(viewModel: viewModel, path: .constant(NavigationPath()))
 }
 
 #Preview("EmotionInputView: Rebound") {
@@ -63,5 +70,5 @@ struct EmotionInputView: View {
         vm.goalType = false
         return vm
     }()
-    EmotionInputView(viewModel: viewModel, currentStep: .constant(.createSubGoal))
+    EmotionInputView(viewModel: viewModel, path: .constant(NavigationPath()))
 }

--- a/Rebound Journal/Screen/Journal/Creation/SubView/ReviewPlanView.swift
+++ b/Rebound Journal/Screen/Journal/Creation/SubView/ReviewPlanView.swift
@@ -22,10 +22,10 @@ struct ReviewPlanView: View {
     @FocusState private var currentField: Field?
     @State var reviewText: String = ""
     @State var planText: String = ""
-    @Binding var currentStep: ReboundProcessStep
     var canSave: Bool { return !reviewText.isEmpty && !planText.isEmpty }
     var isReviewed: Bool {!reviewText.isEmpty || currentField == .review}
     var isPlaned: Bool {!planText.isEmpty || currentField == .plan}
+    @Binding var path: NavigationPath
     
     // etc
     let text = Constants.ContentText()
@@ -35,12 +35,12 @@ struct ReviewPlanView: View {
         VStack(alignment: .leading) {
             Text(viewModel.emotionText?.first ?? "감정태그")
                 .font(.system(size: 16))
-								.foregroundStyle(.black)
+                .foregroundStyle(.black)
                 .padding(.horizontal, 10)
-								.padding(.vertical, 12)
+                .padding(.vertical, 12)
                 .background {
                     Capsule()
-												.fill(.unselectedTagBackground)
+                        .fill(.unselectedTagBackground)
                 }
             
             // Reviewing Shoot
@@ -98,16 +98,10 @@ struct ReviewPlanView: View {
                 hasBackButton: true,
                 canGoNext: canSave,
                 onPrevious: {
-                    currentStep = .emotion
+                    onPreviousTapped()
                 },
                 onNext: {
-                    if viewModel.subGoal != nil {
-                        viewModel.saveJournal(context: modelContext)
-                        currentStep = .selectSubGoal
-                        manager.fullScreenMode = nil
-                    }
-                    else { currentStep = .createSubGoal }
-                    
+                    onNextTapped()
                 },
                 nextButtonText: (viewModel.subGoal != nil) ? systemText.saveButton : systemText.nextButton
             )
@@ -121,6 +115,23 @@ struct ReviewPlanView: View {
         }
         .padding()
     }
+    
+    private func onPreviousTapped() {
+        path.removeLast()
+    }
+    
+    private func onNextTapped() {
+        if viewModel.subGoal != nil {
+            viewModel.saveJournal(context: modelContext)
+            //            currentStep = .selectSubGoal
+            path.append(JournalCreationState.selectSubGoal)
+            manager.fullScreenMode = nil
+        }
+        else {
+            //            currentStep = .createSubGoal
+            path.append(JournalCreationState.createSubGoal)
+        }
+    }
 }
 
 #Preview {
@@ -132,5 +143,5 @@ struct ReviewPlanView: View {
         vm.emotionText = ["기분이 좋은"]
         return vm
     }()
-    ReviewPlanView(viewModel: mockViewModel, currentStep: .constant(.review))
+    ReviewPlanView(viewModel: mockViewModel, path: .constant(NavigationPath()))
 }

--- a/Rebound Journal/Screen/Journal/Creation/SubView/ReviewPlanView.swift
+++ b/Rebound Journal/Screen/Journal/Creation/SubView/ReviewPlanView.swift
@@ -121,14 +121,13 @@ struct ReviewPlanView: View {
     }
     
     private func onNextTapped() {
+        // 선택된 목표가 있을 시
         if viewModel.subGoal != nil {
             viewModel.saveJournal(context: modelContext)
-            //            currentStep = .selectSubGoal
-            path.append(JournalCreationState.selectSubGoal)
             manager.fullScreenMode = nil
         }
+        // 목표가 없을 시
         else {
-            //            currentStep = .createSubGoal
             path.append(JournalCreationState.createSubGoal)
         }
     }

--- a/Rebound Journal/Screen/Journal/Creation/SubView/ReviewPlanView.swift
+++ b/Rebound Journal/Screen/Journal/Creation/SubView/ReviewPlanView.swift
@@ -137,7 +137,6 @@ struct ReviewPlanView: View {
     let mockViewModel = {
         let vm = JournalCreatorViewModel()
         vm.goalType = true
-        vm.currentStep = .review
         vm.emotionValue = 1
         vm.emotionText = ["기분이 좋은"]
         return vm

--- a/Rebound Journal/Screen/Journal/Creation/SubView/SelectShootTypeView.swift
+++ b/Rebound Journal/Screen/Journal/Creation/SubView/SelectShootTypeView.swift
@@ -12,9 +12,9 @@ struct SelectShootTypeView: View {
     @ObservedObject var viewModel: JournalCreatorViewModel
     // UI State
     var isTypeSelected: Bool {viewModel.goalType == nil ? true : false}
-    @Binding var currentStep: ReboundProcessStep
     // etc
     var text = Constants.ContentText()
+    @Binding var path: NavigationPath
     
     var body: some View {
         VStack {
@@ -66,8 +66,7 @@ struct SelectShootTypeView: View {
                 hasBackButton: false,
                 canGoNext: viewModel.goalType != nil,
                 onNext: {
-                    debugPrint("다음 화면으로 이동")
-                    currentStep = .emotion
+                    onNextTapped()
                 },
                 nextButtonText: "다음으로"
             )
@@ -75,9 +74,11 @@ struct SelectShootTypeView: View {
         }
         .padding()
     }
-}
-
-extension SelectShootTypeView {
+    
+    private func onNextTapped() {
+        debugPrint("다음 화면으로 이동")
+        path.append(JournalCreationState.emotion)
+    }
     
     // 타입 비활성화를 위한 함수
     private func toggleSelection(type: Bool?) {
@@ -117,5 +118,5 @@ extension SelectShootTypeView {
 }
 
 #Preview("SelectShootTypeView") {
-    SelectShootTypeView(viewModel: JournalCreatorViewModel(), currentStep: .constant(.selectSubGoal))
+    SelectShootTypeView(viewModel: JournalCreatorViewModel(), path: .constant(NavigationPath()))
 }

--- a/Rebound Journal/Screen/Target/CreateTargetView.swift
+++ b/Rebound Journal/Screen/Target/CreateTargetView.swift
@@ -100,14 +100,10 @@ struct CreateTargetView: View {
         if targetText.isEmpty {
             // 건너뛰기: 목표를 저장하지 않고 다음 단계로
             viewModel.subGoal = nil
-            //                        currentStep = .selectSubGoal
             path.append(JournalCreationState.selectSubGoal)
-            viewModel.saveJournal(context: modelContext)
-            manager.fullScreenMode = nil
         } else {
             // 저장하기: 목표를 저장하고 다음 단계로
             viewModel.subGoal = targetText
-            //                        currentStep = .selectSubGoal
             path.append(JournalCreationState.selectSubGoal)
             viewModel.saveJournal(context: modelContext)
             viewModel.saveSubGoal(context: modelContext)

--- a/Rebound Journal/Screen/Target/CreateTargetView.swift
+++ b/Rebound Journal/Screen/Target/CreateTargetView.swift
@@ -13,10 +13,10 @@ struct CreateTargetView: View {
     @Environment(\.modelContext)private var modelContext
     @EnvironmentObject var manager: DataManager
     @ObservedObject var viewModel: JournalCreatorViewModel
-    @Binding var currentStep: ReboundProcessStep
     @FocusState private var isTextEditorFocused: Bool
     // UI State
     @State var targetText: String = ""
+    @Binding var path: NavigationPath
     
     var body: some View {
         // 전체
@@ -79,23 +79,10 @@ struct CreateTargetView: View {
                 hasBackButton: true,
                 canGoNext: true,  // 건너뛰기도 가능하도록 항상 활성화
                 onPrevious: {
-                    currentStep = .review
+                    onPreviousTapped()
                 },
                 onNext: {
-                    if targetText.isEmpty {
-                        // 건너뛰기: 목표를 저장하지 않고 다음 단계로
-                        viewModel.subGoal = nil
-                        currentStep = .selectSubGoal
-                        viewModel.saveJournal(context: modelContext)
-                        manager.fullScreenMode = nil
-                    } else {
-                        // 저장하기: 목표를 저장하고 다음 단계로
-                        viewModel.subGoal = targetText
-                        currentStep = .selectSubGoal
-                        viewModel.saveJournal(context: modelContext)
-                        viewModel.saveSubGoal(context: modelContext)
-                        manager.fullScreenMode = nil
-                    }
+                    onNextTapped()
                 },
                 nextButtonText: targetText.isEmpty ? "건너뛰기" : "저장하기"
             )
@@ -104,11 +91,34 @@ struct CreateTargetView: View {
         .onAppear { isTextEditorFocused = true }
         .onTapGesture { isTextEditorFocused = false }
     }
+    
+    private func onPreviousTapped() {
+        path.removeLast()
+    }
+    
+    private func onNextTapped() {
+        if targetText.isEmpty {
+            // 건너뛰기: 목표를 저장하지 않고 다음 단계로
+            viewModel.subGoal = nil
+            //                        currentStep = .selectSubGoal
+            path.append(JournalCreationState.selectSubGoal)
+            viewModel.saveJournal(context: modelContext)
+            manager.fullScreenMode = nil
+        } else {
+            // 저장하기: 목표를 저장하고 다음 단계로
+            viewModel.subGoal = targetText
+            //                        currentStep = .selectSubGoal
+            path.append(JournalCreationState.selectSubGoal)
+            viewModel.saveJournal(context: modelContext)
+            viewModel.saveSubGoal(context: modelContext)
+            manager.fullScreenMode = nil
+        }
+    }
 }
 
 #Preview("!targetText.isEmpty") {
-    CreateTargetView(viewModel: JournalCreatorViewModel(), currentStep: .constant(.createSubGoal))
+    CreateTargetView(viewModel: JournalCreatorViewModel(), path: .constant(NavigationPath()))
 }
 #Preview("targetText.isEmpty") {
-    CreateTargetView(viewModel: JournalCreatorViewModel(), currentStep: .constant(.createSubGoal))
+    CreateTargetView(viewModel: JournalCreatorViewModel(), path: .constant(NavigationPath()))
 }

--- a/Rebound Journal/Screen/Target/SelectTargetView.swift
+++ b/Rebound Journal/Screen/Target/SelectTargetView.swift
@@ -101,5 +101,5 @@ struct SelectTargetView: View {
 }
 
 #Preview {
-    SelectTargetView(viewModel: JournalCreatorViewModel(), currentStep: .constant(.createSubGoal), subGoals: [], path: .constant(NavigationPath()))
+    SelectTargetView(viewModel: JournalCreatorViewModel(), subGoals: [], path: .constant(NavigationPath()))
 }

--- a/Rebound Journal/Screen/Target/SelectTargetView.swift
+++ b/Rebound Journal/Screen/Target/SelectTargetView.swift
@@ -9,91 +9,97 @@ import SwiftUI
 import SwiftData
 
 struct SelectTargetView: View {
-		// Shared Dependencies
-		@ObservedObject var viewModel: JournalCreatorViewModel
-		@Binding var currentStep: ReboundProcessStep
-		// UI State
-		@State var subGoals: [SubGoalData]
-		@State private var selectedGoal: SubGoalData?
-
-		var body: some View {
-				VStack {
-						// 질문
-						VStack(alignment: .leading, spacing: 8) {
-								HStack {
-										Text("어떤 슛을 남겨볼까요?")
-												.font(.system(size: 25).bold())
-												.foregroundStyle(.default)
-										Spacer()
-								}
-								HStack {
-										Text("목표에 대한 슛인가요?")
-												.font(.system(size: 18))
-												.foregroundStyle(.description)
-										Spacer()
-								}
-						}
-						.padding(.vertical)
-
-						// 목표 리스트
-						VStack(alignment: .leading, spacing: 8) {
-								ForEach(subGoals, id: \.self) { item in
-										if let text = item.goalText {
-												HStack {
-														Text(text)
-																.padding()
-																.foregroundStyle(.black)
-														Spacer()
-												}
-												.frame(maxWidth: .infinity)
-												.background(Color.cellColor)
-												.overlay(
-														RoundedRectangle(cornerRadius: 12)
-																.stroke(selectedGoal == item ? Color.accentColor : .clear, lineWidth: 2)
-												)
-												.clipShape(RoundedRectangle(cornerRadius: 12))
-												.onTapGesture {
-														if selectedGoal == item {
-																// 이미 선택된 목표를 다시 탭하면 선택 해제
-																selectedGoal = nil
-																viewModel.subGoal = nil
-														} else {
-																// 다른 목표를 탭하면 새로 선택
-																selectedGoal = item
-																viewModel.subGoal = item.goalText
-														}
-												}
-										}
-								}
-						}
-
-						Spacer()
-
-						StepControlView(
-								hasBackButton: false,
-								canGoNext: true,
-								onNext: {
-										if selectedGoal != nil {
-												// 목표를 선택한 경우: 선택된 목표 유지하고 다음으로
-												debugPrint("목표 선택됨: \(viewModel.subGoal ?? "없음")")
-												currentStep = .shoot
-										} else {
-												// 건너뛰기: 목표 선택 없이 다음으로
-												debugPrint("목표 선택 건너뛰기")
-												viewModel.subGoal = nil
-												currentStep = .shoot
-										}
-								},
-								nextButtonText: selectedGoal != nil ? "다음으로" : "건너뛰기"
-						)
-				}
-				.padding()
-				.onAppear {
-						debugPrint("SelectTargetView : \(subGoals.count)")
-				}
-		}
+    // Shared Dependencies
+    @ObservedObject var viewModel: JournalCreatorViewModel
+    // UI State
+    @State var subGoals: [SubGoalData]
+    @State private var selectedGoal: SubGoalData?
+    @Binding var path: NavigationPath
+    
+    var body: some View {
+        VStack {
+            // 질문
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    Text("어떤 슛을 남겨볼까요?")
+                        .font(.system(size: 25).bold())
+                        .foregroundStyle(.default)
+                    Spacer()
+                }
+                HStack {
+                    Text("목표에 대한 슛인가요?")
+                        .font(.system(size: 18))
+                        .foregroundStyle(.description)
+                    Spacer()
+                }
+            }
+            .padding(.vertical)
+            
+            // 목표 리스트
+            VStack(alignment: .leading, spacing: 8) {
+                ForEach(subGoals, id: \.self) { item in
+                    if let text = item.goalText {
+                        HStack {
+                            Text(text)
+                                .padding()
+                                .foregroundStyle(.black)
+                            Spacer()
+                        }
+                        .frame(maxWidth: .infinity)
+                        .background(Color.cellColor)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 12)
+                                .stroke(selectedGoal == item ? Color.accentColor : .clear, lineWidth: 2)
+                        )
+                        .clipShape(RoundedRectangle(cornerRadius: 12))
+                        .onTapGesture {
+                            if selectedGoal == item {
+                                // 이미 선택된 목표를 다시 탭하면 선택 해제
+                                selectedGoal = nil
+                                viewModel.subGoal = nil
+                            } else {
+                                // 다른 목표를 탭하면 새로 선택
+                                selectedGoal = item
+                                viewModel.subGoal = item.goalText
+                            }
+                        }
+                    }
+                }
+            }
+            
+            Spacer()
+            
+            StepControlView(
+                hasBackButton: false,
+                canGoNext: true,
+                onNext: {
+                    onNextTapped()
+                },
+                nextButtonText: selectedGoal != nil ? "다음으로" : "건너뛰기"
+            )
+        }
+        .padding()
+        .onAppear {
+            debugPrint("SelectTargetView : \(subGoals.count)")
+        }
+    }
+    
+    private func onNextTapped() {
+        if selectedGoal != nil {
+            // 목표를 선택한 경우: 선택된 목표 유지하고 다음으로
+            debugPrint("목표 선택됨: \(viewModel.subGoal ?? "없음")")
+//            currentStep = .shoot
+            path.append(JournalCreationState.shoot)
+        } else {
+            // 건너뛰기: 목표 선택 없이 다음으로
+            debugPrint("목표 선택 건너뛰기")
+            viewModel.subGoal = nil
+//            currentStep = .shoot
+            path.append(JournalCreationState.shoot)
+        }
+    }
 }
 
 #Preview {
-		SelectTargetView(viewModel: JournalCreatorViewModel(), currentStep: .constant(.createSubGoal), subGoals: [])
+    SelectTargetView(viewModel: JournalCreatorViewModel(), currentStep: .constant(.createSubGoal), subGoals: [], path: .constant(NavigationPath()))
 }

--- a/Rebound Journal/Screen/Target/SelectTargetView.swift
+++ b/Rebound Journal/Screen/Target/SelectTargetView.swift
@@ -80,7 +80,7 @@ struct SelectTargetView: View {
         }
         .padding()
         .onAppear {
-            debugPrint("SelectTargetView : \(subGoals.count)")
+            debugPrint("TargetCount : \(subGoals.count)")
         }
     }
     
@@ -88,13 +88,11 @@ struct SelectTargetView: View {
         if selectedGoal != nil {
             // 목표를 선택한 경우: 선택된 목표 유지하고 다음으로
             debugPrint("목표 선택됨: \(viewModel.subGoal ?? "없음")")
-//            currentStep = .shoot
             path.append(JournalCreationState.shoot)
         } else {
             // 건너뛰기: 목표 선택 없이 다음으로
             debugPrint("목표 선택 건너뛰기")
             viewModel.subGoal = nil
-//            currentStep = .shoot
             path.append(JournalCreationState.shoot)
         }
     }

--- a/Rebound Journal/ViewModel/Journal/Creation/JournalCreatorViewModel.swift
+++ b/Rebound Journal/ViewModel/Journal/Creation/JournalCreatorViewModel.swift
@@ -8,17 +8,9 @@
 import Foundation
 import SwiftData
 
-enum ReboundProcessStep: CaseIterable {
-    case selectSubGoal, // 작은 목표 설정
-         shoot, // 슛 타입
-         emotion, // 현재 감정
-         review, // 느낀점 & 향후계획
-         createSubGoal // 작은 목표 생성
-}
 class JournalCreatorViewModel: ObservableObject {
     
     // UI State
-    @Published var currentStep: ReboundProcessStep = .selectSubGoal
     @Published var isSliderEditing: Bool = false
     
     // Data


### PR DESCRIPTION
# 개요
저널 생성 중 중단 후 다시 생성 시작 했을 때, 처음 화면이 아닌
중단했던 화면부터 시작되는 오류를 해결하는 과정에서
`FullScreenCover`보다는 `NavigationStack`으로 변경하고
`NavigationPath`로 화면을 관리하는 것이 안정적일 것 같아서 변경하는 작업을 진행.

# 주요 내용
- `JournalCreator`의 화면전환 방식이 `NavigationStack`으로 변경됨.
- `JournalProcessStep` 등 사용하지 않는 코드들 삭제
- `NavigationPath`를 통한 화면 전환 및 관리

### 관련 이슈
close #64 